### PR TITLE
Add CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8)
+
+project (mit-hrtf-lib)
+set(CMAKE_BUILD_TYPE Release)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/source)
+include_directories(${PROJECT_SOURCE_DIR}/source/normal)
+
+add_library(libmit_hrtf_lib STATIC ${PROJECT_SOURCE_DIR}/source/mit_hrtf_lib.c)


### PR DESCRIPTION
This PR allows to build the mit-hrtf-lib with cmake.

On linux system at the top dir,

1, mkdir build
2, cd build
3, cmake ../CMakeLists.txt
4, make

